### PR TITLE
Updated the base node image in Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.13.1
       - run: npm ci
       - run: npm test
 
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.13.1
       - run: npm ci
       - run: node bin/migrate.js
       - run: npm test
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.13.1
       - run: npm ci
       - run: npm run lint
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Adjust NODE_VERSION as desired
-ARG NODE_VERSION=20.12.2
+ARG NODE_VERSION=22.13.1
 FROM node:${NODE_VERSION}-slim AS base
 
 LABEL fly_launch_runtime="nodejs"


### PR DESCRIPTION
Partially Fixes https://github.com/CheckerNetwork/roadmap/issues/210

Updated the Node.js base image from node:20.12.2-slim to node:22.13.1-slim, an LTS version, as requested in issue #210 of the roadmap repository.