### PR TITLE
fix: deduplicate list of clients in retrieval tasks

### DIFF
--- a/api/lib/round-tracker.js
+++ b/api/lib/round-tracker.js
@@ -307,7 +307,7 @@ export async function maybeCreateSparkRound (pgClient, {
   }
 }
 
-async function defineTasksForRound (pgClient, sparkRoundNumber, taskCount) {
+export async function defineTasksForRound (pgClient, sparkRoundNumber, taskCount) {
   await pgClient.query(`
     INSERT INTO retrieval_tasks (round_id, cid, miner_id, clients)
     WITH selected AS (
@@ -317,7 +317,7 @@ async function defineTasksForRound (pgClient, sparkRoundNumber, taskCount) {
       ORDER BY random()
       LIMIT $2
     )
-    SELECT $1 as round_id, selected.payload_cid as cid, selected.miner_id, array_agg(client_id) as clients
+    SELECT $1 as round_id, selected.payload_cid as cid, selected.miner_id, array_agg(DISTINCT client_id) as clients
     FROM selected
     LEFT JOIN eligible_deals
     ON selected.payload_cid = eligible_deals.payload_cid AND selected.miner_id = eligible_deals.miner_id

--- a/api/test/round-tracker.test.js
+++ b/api/test/round-tracker.test.js
@@ -563,15 +563,24 @@ describe('Round Tracker', () => {
     })
 
     describe('defineTasksForRound', () => {
+      before(async () => {
+        // Mark all existing deals as expired
+        await pgClient.query(`
+          UPDATE eligible_deals SET expires_at = NOW() - INTERVAL '1 day'
+        `)
+      })
+
+      after(async () => {
+        // Revert the change that expired existing deals
+        await pgClient.query(`
+          UPDATE eligible_deals SET expires_at = NOW() + INTERVAL '1 year'
+        `)
+      })
+
       it('merges duplicate clients', async () => {
         // Delete any eligible deals created by previous test runs
         await pgClient.query(`
           DELETE FROM eligible_deals WHERE client_id = 'f0050'
-        `)
-
-        // Mark all existing deals as expired
-        await pgClient.query(`
-          UPDATE eligible_deals SET expires_at = NOW() - INTERVAL '1 day'
         `)
 
         // Create deals from the same client. First two deals are with the same SP, the third is not.

--- a/api/test/round-tracker.test.js
+++ b/api/test/round-tracker.test.js
@@ -576,7 +576,7 @@ describe('Round Tracker', () => {
 
         // Create deals from the same client. First two deals are with the same SP, the third is not.
         // All deals have the same payload_cid.
-        // Only these two deals will be available for sampling
+        // Only these deals will be available for sampling
         await pgClient.query(`
           INSERT INTO eligible_deals
           (miner_id, client_id, piece_cid, piece_size, payload_cid, expires_at, sourced_from_f05_state)

--- a/api/test/round-tracker.test.js
+++ b/api/test/round-tracker.test.js
@@ -564,7 +564,7 @@ describe('Round Tracker', () => {
 
     describe('defineTasksForRound', () => {
       it('merges duplicate clients', async () => {
-        // Delete any eligible deals create by previous test runs
+        // Delete any eligible deals created by previous test runs
         await pgClient.query(`
           DELETE FROM eligible_deals WHERE client_id = 'f0050'
         `)


### PR DESCRIPTION
Recently, we discovered that there is a lot of deals using the same payload CID `bafkqaaa`. There are more than 22k deals, but only between 27 miners and 9 clients. As a result, when one of such deals is picked for testing, the list of clients is very long and full of duplicates.

Example:
https://api.filspark.com/rounds/meridian/0x8460766edc62b525fc1fa4d628fc79229dc73031/25039

In this change, I am modifying the query sampling eligible deals to de-duplicate the list of clients in each task.
