### PR TITLE
Revert "Bump node from 22.13.1-slim to 23.8.0-slim"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1
 
-FROM node:23.8.0-slim AS base
+FROM node:22.13.1-slim AS base
 
 LABEL fly_launch_runtime="nodejs"
 


### PR DESCRIPTION
Reverts CheckerNetwork/spark-api#531

> We shouldn't upgrade to odd major versions of Node.js - @juliangruber 


