### PR TITLE
Add typescript type checking

### DIFF
--- a/api/bin/spark.js
+++ b/api/bin/spark.js
@@ -70,7 +70,7 @@ setInterval(clearNetworkInfoStationIdsSeen, 1000 * 60 * 60 * 24)
 const logger = {
   error: console.error,
   info: console.info,
-  request: ['1', 'true'].includes(REQUEST_LOGGING) ? console.info : () => {}
+  request: ['1', 'true'].includes(REQUEST_LOGGING) ? console.info : () => { }
 }
 
 const handler = await createHandler({
@@ -79,8 +79,10 @@ const handler = await createHandler({
   dealIngestionAccessToken: DEAL_INGESTER_TOKEN,
   domain: DOMAIN
 })
+
+const port = Number(PORT)
 const server = http.createServer(handler)
-console.log('Starting the http server on host %j port %s', HOST, PORT)
-server.listen(PORT, HOST)
+console.log('Starting the http server on host %j port %s', HOST, port)
+server.listen(port, HOST)
 await once(server, 'listening')
 console.log(`http://${HOST}:${PORT}`)

--- a/api/bin/spark.js
+++ b/api/bin/spark.js
@@ -47,7 +47,7 @@ client.on('error', err => {
 await migrate(client)
 
 console.log('Initializing round tracker...')
-const start = Date.now()
+const start = new Date()
 
 try {
   const currentRound = await startRoundTracker({
@@ -56,7 +56,7 @@ try {
   })
   console.log(
     'Initialized round tracker in %sms. SPARK round number at service startup: %s',
-    Date.now() - start,
+    new Date().getTime() - start.getTime(),
     currentRound.sparkRoundNumber
   )
 } catch (err) {

--- a/api/index.js
+++ b/api/index.js
@@ -55,7 +55,7 @@ const handler = async (req, res, client, domain, dealIngestionAccessToken) => {
 
 const createMeasurement = async (req, res, client) => {
   const body = await getRawBody(req, { limit: '100kb' })
-  const measurement = JSON.parse(body)
+  const measurement = JSON.parse(body.toString())
   validate(measurement, 'sparkVersion', { type: 'string', required: false })
   validate(measurement, 'zinniaVersion', { type: 'string', required: false })
   assert(
@@ -205,7 +205,7 @@ const getRoundDetails = async (req, res, client, roundParam) => {
     const meridianContractAddress = round.meridian_address
     const meridianRoundIndex = BigInt(round.meridian_round)
     const addr = encodeURIComponent(meridianContractAddress)
-    const idx = encodeURIComponent(meridianRoundIndex)
+    const idx = encodeURIComponent(meridianRoundIndex.toString())
     const location = `/rounds/meridian/${addr}/${idx}`
 
     // Cache the location of the current round for a short time to ensure clients learn quickly
@@ -413,7 +413,7 @@ export const ingestEligibleDeals = async (req, res, client, dealIngestionAccessT
   }
 
   const body = await getRawBody(req, { limit: '100mb' })
-  const deals = JSON.parse(body)
+  const deals = JSON.parse(body.toString())
   assert(Array.isArray(deals), 400, 'Invalid JSON Body, must be an array')
   for (const d of deals) {
     validate(d, 'clientId', { type: 'string', required: true })
@@ -463,12 +463,12 @@ export const createHandler = async ({
   domain
 }) => {
   return (req, res) => {
-    const start = new Date()
+    const start = Date.now()
     logger.request(`${req.method} ${req.url} ...`)
     handler(req, res, client, domain, dealIngestionAccessToken)
       .catch(err => errorHandler(res, err, logger))
       .then(() => {
-        logger.request(`${req.method} ${req.url} ${res.statusCode} (${new Date() - start}ms)`)
+        logger.request(`${req.method} ${req.url} ${res.statusCode} (${Date.now() - start}ms)`)
       })
   }
 }

--- a/api/index.js
+++ b/api/index.js
@@ -468,7 +468,7 @@ export const createHandler = async ({
     handler(req, res, client, domain, dealIngestionAccessToken)
       .catch(err => errorHandler(res, err, logger))
       .then(() => {
-        logger.request(`${req.method} ${req.url} ${res.statusCode} (${Date.now() - start}ms)`)
+        logger.request(`${req.method} ${req.url} ${res.statusCode} (${new Date().getTime() - start.getTime()}ms)`)
       })
   }
 }

--- a/api/index.js
+++ b/api/index.js
@@ -463,7 +463,7 @@ export const createHandler = async ({
   domain
 }) => {
   return (req, res) => {
-    const start = Date.now()
+    const start = new Date()
     logger.request(`${req.method} ${req.url} ...`)
     handler(req, res, client, domain, dealIngestionAccessToken)
       .catch(err => errorHandler(res, err, logger))

--- a/api/lib/inet-grouping.js
+++ b/api/lib/inet-grouping.js
@@ -4,9 +4,9 @@ import { base64url } from 'multiformats/bases/base64'
 const IPV4_REGEX = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.){3}(25[0-5]|(2[0-4]|1\d|[1-9]|)\d)$/
 
 /**
- * @param {import('pg').Client} client
+ * @param {import('pg').Client} pgClient
  * @param {import('node:http').IncomingMessage} req
- * @returns {string}
+ * @returns {Promise<string>}
  */
 export const mapRequestToInetGroup = async (pgClient, req) => {
   const subnet = mapRequestToSubnet(req)
@@ -16,7 +16,7 @@ export const mapRequestToInetGroup = async (pgClient, req) => {
 }
 
 /**
- * @param {import('pg').Client} client
+ * @param {import('pg').Client} pgClient
  * @param {string} subnet
  * @returns {Promise<string>}
  */
@@ -77,13 +77,13 @@ export const mapRequestToSubnet = (req) => {
   let addr = req.socket.remoteAddress
 
   const flyClientAddr = req.headers['fly-client-ip']
-  if (flyClientAddr) addr = flyClientAddr
+  if (flyClientAddr && typeof flyClientAddr === 'string') addr = flyClientAddr
 
   // TODO accept the value in this header only when the request is coming from Cloudflare
   // Check that `req.socket.remoteAddress` matches one of the well-known Cloudflare's addresses
   // See https://www.cloudflare.com/en-gb/ips/
   const cfAddr = req.headers['cf-connecting-ip']
-  if (cfAddr) addr = cfAddr
+  if (cfAddr && typeof cfAddr === 'string') addr = cfAddr
 
   if (!addr) return undefined
 

--- a/api/lib/network-info-logger.js
+++ b/api/lib/network-info-logger.js
@@ -5,7 +5,7 @@ export const clearNetworkInfoStationIdsSeen = () => {
 }
 
 /**
- * @param {import('node:http').IncomingMessage} req
+ * @param {import('node:http').IncomingHttpHeaders} headers
  * @param {string} stationId
  * @param {import('../../common/typings.js').RecordTelemetryFn} recordTelemetry
  */

--- a/api/lib/round-tracker.js
+++ b/api/lib/round-tracker.js
@@ -370,8 +370,8 @@ export async function getRoundStartEpoch (contract, roundIndex, blocks) {
 
   const recentRoundStartEvents = (await contract.queryFilter('RoundStart', -blocks))
     .map(log => {
-      const decoded = contract.interface.decodeEventLog('RoundStart', log.data, log.topics);
-      return { blockNumber: log.blockNumber, roundIndex: decoded[0] };
+      const decoded = contract.interface.decodeEventLog('RoundStart', log.data, log.topics)
+      return { blockNumber: log.blockNumber, roundIndex: decoded[0] }
     })
 
   const roundStart = recentRoundStartEvents.find(e => e.roundIndex === roundIndex)

--- a/api/lib/round-tracker.js
+++ b/api/lib/round-tracker.js
@@ -369,10 +369,7 @@ export async function getRoundStartEpoch (contract, roundIndex, blocks) {
   assert.strictEqual(typeof blocks, 'number', `blocks must be a number, received: ${typeof blocks}`)
 
   const recentRoundStartEvents = (await contract.queryFilter('RoundStart', -blocks))
-    .map(log => {
-      const decoded = contract.interface.decodeEventLog('RoundStart', log.data, log.topics)
-      return { blockNumber: log.blockNumber, roundIndex: decoded[0] }
-    })
+    .map((/** @type {import('ethers').EventLog} */ { blockNumber, args }) => ({ blockNumber, roundIndex: args[0] }))
 
   const roundStart = recentRoundStartEvents.find(e => e.roundIndex === roundIndex)
   if (!roundStart) {

--- a/api/lib/round-tracker.js
+++ b/api/lib/round-tracker.js
@@ -339,7 +339,7 @@ export async function getRoundStartEpochWithBackoff (
 ) {
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
-      const roundStartEpoch =  await getRoundStartEpoch(
+      const roundStartEpoch = await getRoundStartEpoch(
         contract,
         roundIndex,
         50 * (2 ** attempt)

--- a/api/test/network-info-logger.test.js
+++ b/api/test/network-info-logger.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert'
-import { createTelemetryRecorderStub } from '../../test-helpers/platform-test-helpers.js'
+import { createTelemetryRecorderStub, getPointName } from '../../test-helpers/platform-test-helpers.js'
 import { clearNetworkInfoStationIdsSeen, logNetworkInfo } from '../lib/network-info-logger.js'
 
 describe('logNetworkInfo', () => {
@@ -56,8 +56,7 @@ describe('logNetworkInfo', () => {
     }
 
     assert.deepStrictEqual(
-      // @ts-ignore
-      telemetry.map(p => ({ _point: p.name, ...p.fields })),
+      telemetry.map(p => ({ _point: getPointName(p), ...p.fields })),
       [
         { _point: 'network-info', ...expectedFields1 },
         { _point: 'network-info', ...expectedFields2 }
@@ -80,8 +79,7 @@ describe('logNetworkInfo', () => {
 
     assert.strictEqual(telemetry.length, 2)
     assert.deepStrictEqual(
-      // @ts-ignore
-      telemetry.map(p => ({ _point: p.name, 'cf-ipcity': p.fields['cf-ipcity'] })),
+      telemetry.map(p => ({ _point: getPointName(p), 'cf-ipcity': p.fields['cf-ipcity'] })),
       [
         { _point: 'network-info', 'cf-ipcity': '"city1"' },
         { _point: 'network-info', 'cf-ipcity': '"city3"' }

--- a/api/test/network-info-logger.test.js
+++ b/api/test/network-info-logger.test.js
@@ -13,14 +13,27 @@ describe('logNetworkInfo', () => {
     'cf-region-code': 'region-code1',
     'cf-timezone': 'timezone1'
   }
-  const headers2 = {}
-  for (const key in headers1) {
-    headers2[key] = headers1[key].slice(0, -1) + '2'
+  const headers2 = {
+    'cf-ipcity': 'city2',
+    'cf-ipcountry': 'country2',
+    'cf-ipcontinent': 'continent2',
+    'cf-iplongitude': 'longitude2',
+    'cf-iplatitude': 'latitude2',
+    'cf-region': 'region2',
+    'cf-region-code': 'region-code2',
+    'cf-timezone': 'timezone2'
   }
-  const headers3 = {}
-  for (const key in headers1) {
-    headers3[key] = headers1[key].slice(0, -1) + '3'
+  const headers3 = {
+    'cf-ipcity': 'city3',
+    'cf-ipcountry': 'country3',
+    'cf-ipcontinent': 'continent3',
+    'cf-iplongitude': 'longitude3',
+    'cf-iplatitude': 'latitude3',
+    'cf-region': 'region3',
+    'cf-region-code': 'region-code3',
+    'cf-timezone': 'timezone3'
   }
+  
 
   beforeEach(async () => {
     clearNetworkInfoStationIdsSeen()
@@ -44,6 +57,7 @@ describe('logNetworkInfo', () => {
     }
 
     assert.deepStrictEqual(
+      // @ts-ignore
       telemetry.map(p => ({ _point: p.name, ...p.fields })),
       [
         { _point: 'network-info', ...expectedFields1 },
@@ -67,6 +81,7 @@ describe('logNetworkInfo', () => {
 
     assert.strictEqual(telemetry.length, 2)
     assert.deepStrictEqual(
+      // @ts-ignore
       telemetry.map(p => ({ _point: p.name, 'cf-ipcity': p.fields['cf-ipcity'] })),
       [
         { _point: 'network-info', 'cf-ipcity': '"city1"' },

--- a/api/test/network-info-logger.test.js
+++ b/api/test/network-info-logger.test.js
@@ -33,7 +33,6 @@ describe('logNetworkInfo', () => {
     'cf-region-code': 'region-code3',
     'cf-timezone': 'timezone3'
   }
-  
 
   beforeEach(async () => {
     clearNetworkInfoStationIdsSeen()

--- a/api/test/round-tracker.test.js
+++ b/api/test/round-tracker.test.js
@@ -16,7 +16,7 @@ import { migrate } from '../../migrations/index.js'
 import { assertApproximately } from '../../test-helpers/assert.js'
 import { createMeridianContract } from '../lib/ie-contract.js'
 import { afterEach, beforeEach } from 'mocha'
-import { createTelemetryRecorderStub } from '../../test-helpers/platform-test-helpers.js'
+import { createTelemetryRecorderStub, getPointName } from '../../test-helpers/platform-test-helpers.js'
 
 const { DATABASE_URL } = process.env
 
@@ -77,7 +77,7 @@ describe('Round Tracker', () => {
       // first round number was correctly initialised
       assert.strictEqual(await getFirstRoundForContractAddress(pgClient, '0x1a'), '1')
       assert.deepStrictEqual(
-        telemetry.map(p => ({ _point: p.name, ...p.fields })),
+        telemetry.map(p => ({ _point: getPointName(p), ...p.fields })),
         [
           {
             _point: 'round',
@@ -109,7 +109,7 @@ describe('Round Tracker', () => {
       // first round number was not changed
       assert.strictEqual(await getFirstRoundForContractAddress(pgClient, '0x1a'), '1')
       assert.deepStrictEqual(
-        telemetry.map(p => ({ _point: p.name, ...p.fields }))[1],
+        telemetry.map(p => ({ _point: getPointName(p), ...p.fields }))[1],
         {
           _point: 'round',
           current_round_measurement_count_target: `${TASKS_EXECUTED_PER_ROUND}i`,
@@ -135,7 +135,7 @@ describe('Round Tracker', () => {
       })
       assert.strictEqual(sparkRoundNumber, 1n)
       assert.deepStrictEqual(
-        telemetry.map(p => ({ _point: p.name, ...p.fields })),
+        telemetry.map(p => ({ _point: getPointName(p), ...p.fields })),
         [
           {
             _point: 'round',
@@ -185,7 +185,7 @@ describe('Round Tracker', () => {
       // first round number was not changed
       assert.strictEqual(await getFirstRoundForContractAddress(pgClient, '0x1b'), '2')
       assert.deepStrictEqual(
-        telemetry.map(p => ({ _point: p.name, ...p.fields }))[1],
+        telemetry.map(p => ({ _point: getPointName(p), ...p.fields }))[1],
         {
           _point: 'round',
           current_round_measurement_count_target: `${TASKS_EXECUTED_PER_ROUND}i`,
@@ -220,7 +220,7 @@ describe('Round Tracker', () => {
       assert.strictEqual(sparkRounds[0].meridian_address, '0x1a')
       assert.strictEqual(sparkRounds[0].meridian_round, '1')
       assert.deepStrictEqual(
-        telemetry.map(p => ({ _point: p.name, ...p.fields })),
+        telemetry.map(p => ({ _point: getPointName(p), ...p.fields })),
         [
           {
             _point: 'round',
@@ -239,7 +239,8 @@ describe('Round Tracker', () => {
         meridianContractAddress,
         meridianRoundIndex,
         roundStartEpoch,
-        pgClient
+        pgClient,
+        recordTelemetry
       })
       assert.strictEqual(sparkRoundNumber, 1n)
       sparkRounds = (await pgClient.query('SELECT * FROM spark_rounds ORDER BY id')).rows
@@ -270,7 +271,7 @@ describe('Round Tracker', () => {
         assert.match(t.miner_id, /^f0/, `task#${ix} miner_id should match /^f0/, found ${t.miner_id}`)
       }
       assert.deepStrictEqual(
-        telemetry.map(p => ({ _point: p.name, ...p.fields })),
+        telemetry.map(p => ({ _point: getPointName(p), ...p.fields })),
         [
           {
             _point: 'round',
@@ -314,7 +315,7 @@ describe('Round Tracker', () => {
         assert.strictEqual(BigInt(t.round_id), firstRoundNumber)
       }
       assert.deepStrictEqual(
-        telemetry.map(p => ({ _point: p.name, ...p.fields })),
+        telemetry.map(p => ({ _point: getPointName(p), ...p.fields })),
         [
           {
             _point: 'round',
@@ -348,7 +349,7 @@ describe('Round Tracker', () => {
       assert.deepStrictEqual(sparkRounds.map(r => r.id), ['1'])
       assert.strictEqual(sparkRounds[0].max_tasks_per_node, 15)
       assert.deepStrictEqual(
-        telemetry.map(p => ({ _point: p.name, ...p.fields })),
+        telemetry.map(p => ({ _point: getPointName(p), ...p.fields })),
         [
           {
             _point: 'round',
@@ -384,7 +385,7 @@ describe('Round Tracker', () => {
         )
         assert.strictEqual(retrievalTasks.length, BASELINE_TASKS_PER_ROUND)
         assert.deepStrictEqual(
-          telemetry.map(p => ({ _point: p.name, ...p.fields })),
+          telemetry.map(p => ({ _point: getPointName(p), ...p.fields })),
           [
             {
               _point: 'round',
@@ -426,7 +427,7 @@ describe('Round Tracker', () => {
         )
         assert.strictEqual(retrievalTasks.length, BASELINE_TASKS_PER_ROUND)
         assert.deepStrictEqual(
-          telemetry.map(p => ({ _point: p.name, ...p.fields })),
+          telemetry.map(p => ({ _point: getPointName(p), ...p.fields })),
           [
             {
               _point: 'round',
@@ -491,7 +492,7 @@ describe('Round Tracker', () => {
             [prevSparkRoundNumber]
           )
           assert.deepStrictEqual(
-            telemetry.map(p => ({ _point: p.name, ...p.fields })),
+            telemetry.map(p => ({ _point: getPointName(p), ...p.fields })),
             [
               {
                 _point: 'round',
@@ -660,7 +661,7 @@ describe('Round Tracker', () => {
       })
       assert.strictEqual(typeof sparkRoundNumber, 'bigint')
       assert.deepStrictEqual(
-        telemetry.map(p => ({ _point: p.name, ...p.fields })),
+        telemetry.map(p => ({ _point: getPointName(p), ...p.fields })),
         [
           {
             _point: 'round',

--- a/api/test/round-tracker.test.js
+++ b/api/test/round-tracker.test.js
@@ -635,7 +635,7 @@ describe('Round Tracker', () => {
       const contract = await createMeridianContract()
       const roundIndex = await contract.currentRoundIndex()
       const startEpoch = await getRoundStartEpoch(contract, roundIndex, 500)
-      assert.strictEqual(typeof startEpoch, 'number')
+      assert.strictEqual(typeof startEpoch, 'bigint')
     })
   })
 
@@ -645,7 +645,7 @@ describe('Round Tracker', () => {
       const contract = await createMeridianContract()
       const roundIndex = await contract.currentRoundIndex()
       const startEpoch = await getRoundStartEpochWithBackoff(contract, roundIndex)
-      assert.strictEqual(typeof startEpoch, 'number')
+      assert.strictEqual(typeof startEpoch, 'bigint')
     })
   })
 

--- a/api/test/test.js
+++ b/api/test/test.js
@@ -643,6 +643,7 @@ describe('Routes', () => {
             error: console.error,
             request () {}
           },
+          dealIngestionAccessToken: VALID_DEAL_INGESTION_TOKEN,
           domain: 'foobar'
         })
         server = http.createServer(handler)

--- a/api/test/test.js
+++ b/api/test/test.js
@@ -9,7 +9,7 @@ import {
   mapCurrentMeridianRoundToSparkRound,
   BASELINE_TASKS_PER_NODE
 } from '../lib/round-tracker.js'
-import { delegatedFromEthAddress } from '@glif/filecoin-address'
+import { delegatedFromEthAddress, CoinType } from '@glif/filecoin-address'
 import { createTelemetryRecorderStub } from '../../test-helpers/platform-test-helpers.js'
 
 const { DATABASE_URL } = process.env
@@ -79,7 +79,8 @@ describe('Routes', () => {
     server = http.createServer(handler)
     server.listen()
     await once(server, 'listening')
-    spark = `http://127.0.0.1:${server.address().port}`
+    const { port } = /** @type {import('node:net').AddressInfo} */ (server.address())
+    spark = `http://127.0.0.1:${port}`
   })
 
   after(async () => {
@@ -153,6 +154,7 @@ describe('Routes', () => {
         body: JSON.stringify(measurement)
       })
       await assertResponseStatus(createRequest, 200)
+      /** @type {any} */
       const { id } = await createRequest.json()
 
       const { rows: [measurementRow] } = await client.query(`
@@ -209,6 +211,7 @@ describe('Routes', () => {
         body: JSON.stringify(measurement)
       })
       await assertResponseStatus(createRequest, 200)
+      /** @type {any} */
       const { id } = await createRequest.json()
 
       const { rows: [measurementRow] } = await client.query(`
@@ -226,7 +229,7 @@ describe('Routes', () => {
 
       const measurement = {
         ...VALID_MEASUREMENT,
-        participantAddress: delegatedFromEthAddress(participantAddress, 'f')
+        participantAddress: delegatedFromEthAddress(participantAddress, CoinType.MAIN)
       }
 
       const createRequest = await fetch(`${spark}/measurements`, {
@@ -235,6 +238,7 @@ describe('Routes', () => {
         body: JSON.stringify(measurement)
       })
       await assertResponseStatus(createRequest, 200)
+      /** @type {any} */
       const { id } = await createRequest.json()
 
       const { rows: [measurementRow] } = await client.query(`
@@ -252,7 +256,7 @@ describe('Routes', () => {
 
       const measurement = {
         ...VALID_MEASUREMENT,
-        participantAddress: `${delegatedFromEthAddress(participantAddress, 'f')}0`
+        participantAddress: `${delegatedFromEthAddress(participantAddress, CoinType.MAIN)}0`
       }
 
       const createRequest = await fetch(`${spark}/measurements`, {
@@ -280,6 +284,7 @@ describe('Routes', () => {
         body: JSON.stringify(measurement)
       })
       await assertResponseStatus(createRequest, 200)
+      /** @type {any} */
       const { id } = await createRequest.json()
 
       const { rows: [measurementRow] } = await client.query(`
@@ -346,6 +351,7 @@ describe('Routes', () => {
         body: JSON.stringify(measurement)
       })
       await assertResponseStatus(createRequest, 200)
+      /** @type {any} */
       const { id } = await createRequest.json()
 
       const { rows: [measurementRow] } = await client.query(`
@@ -375,6 +381,7 @@ describe('Routes', () => {
         body: JSON.stringify(measurement)
       })
       await assertResponseStatus(createRequest, 200)
+      /** @type {any} */
       const { id } = await createRequest.json()
 
       const { rows: [measurementRow] } = await client.query(`
@@ -427,10 +434,12 @@ describe('Routes', () => {
         body: JSON.stringify(measurement)
       })
       await assertResponseStatus(createRequest, 200)
+      /** @type {any} */
       const { id: measurementId } = await createRequest.json()
 
       const res = await fetch(`${spark}/measurements/${measurementId}`)
       await assertResponseStatus(res, 200)
+      /** @type {any} */
       const body = await res.json()
       assert.strictEqual(body.id, measurementId)
       assert.strictEqual(body.cid, measurement.cid)
@@ -493,6 +502,7 @@ describe('Routes', () => {
     it('returns details of the correct SPARK round', async () => {
       const res = await fetch(`${spark}/rounds/meridian/0xNEW/120`)
       await assertResponseStatus(res, 200)
+      /** @type {any} */
       const { retrievalTasks, ...details } = await res.json()
 
       assert.deepStrictEqual(details, {
@@ -513,6 +523,7 @@ describe('Routes', () => {
     it('returns details of a SPARK round managed by older contract version', async () => {
       const res = await fetch(`${spark}/rounds/meridian/0xOLD/10`)
       await assertResponseStatus(res, 200)
+      /** @type {any} */
       const { retrievalTasks, ...details } = await res.json()
 
       assert.deepStrictEqual(details, {
@@ -557,6 +568,7 @@ describe('Routes', () => {
     it('returns all properties of the current round after redirect', async () => {
       const res = await fetch(`${spark}/rounds/current`)
       await assertResponseStatus(res, 200)
+      /** @type {any} */
       const body = await res.json()
 
       assert.deepStrictEqual(Object.keys(body), [
@@ -605,6 +617,7 @@ describe('Routes', () => {
     it('returns all properties of the specified round', async () => {
       const res = await fetch(`${spark}/rounds/${currentSparkRoundNumber}`)
       await assertResponseStatus(res, 200)
+      /** @type {any} */
       const body = await res.json()
 
       assert.deepStrictEqual(Object.keys(body), [
@@ -649,7 +662,8 @@ describe('Routes', () => {
         server = http.createServer(handler)
         server.listen()
         await once(server, 'listening')
-        const spark = `http://127.0.0.1:${server.address().port}`
+        const { port } = /** @type {import('node:net').AddressInfo} */ (server.address())
+        const spark = `http://127.0.0.1:${port}`
         const res = await fetch(
           `${spark}/rounds/${currentSparkRoundNumber}`,
           { redirect: 'manual' }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,11 @@
         "publish"
       ],
       "devDependencies": {
-        "standard": "^17.1.2"
+        "@types/mocha": "^10.0.10",
+        "@types/node": "^22.13.5",
+        "@types/pg": "^8.11.11",
+        "standard": "^17.1.2",
+        "typescript": "^5.7.3"
       }
     },
     "api": {
@@ -1252,6 +1256,17 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-pg/node_modules/@types/pg": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
+      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation-redis-4": {
       "version": "0.46.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.0.tgz",
@@ -1645,6 +1660,13 @@
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
       "license": "MIT"
     },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mysql": {
       "version": "2.15.26",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
@@ -1655,22 +1677,23 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "version": "22.13.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
+      "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/pg": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
-      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
+      "version": "8.11.11",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.11.tgz",
+      "integrity": "sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
-        "pg-types": "^2.2.0"
+        "pg-types": "^4.0.1"
       }
     },
     "node_modules/@types/pg-pool": {
@@ -1680,6 +1703,63 @@
       "license": "MIT",
       "dependencies": {
         "@types/pg": "*"
+      }
+    },
+    "node_modules/@types/pg/node_modules/pg-types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
+      "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.1.0",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-array": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
+      "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "license": "MIT",
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-date": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@types/retry": {
@@ -3658,10 +3738,25 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
     "node_modules/ethers/node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
@@ -5363,6 +5458,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "dev": true,
@@ -5651,6 +5752,15 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/pg-pool": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.7.1.tgz",
@@ -5867,6 +5977,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -6815,6 +6931,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uint8arraylist": {
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.8.tgz",
@@ -6859,9 +6989,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,16 @@
   "scripts": {
     "migrate": "node bin/migrate.js",
     "lint": "standard",
-    "test": "npm run lint && npm test --workspaces"
+    "test:types": "tsc -p .",
+    "test:unit": "npm test --workspaces --if-present",
+    "test": "npm run lint && npm run test:types && npm run test:unit"
   },
   "devDependencies": {
-    "standard": "^17.1.2"
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^22.13.5",
+    "@types/pg": "^8.11.11",
+    "standard": "^17.1.2",
+    "typescript": "^5.7.3"
   },
   "standard": {
     "env": [

--- a/publish/bin/publish-batch.js
+++ b/publish/bin/publish-batch.js
@@ -27,6 +27,7 @@ assert(WALLET_SEED, 'WALLET_SEED required')
 assert(W3UP_PRIVATE_KEY, 'W3UP_PRIVATE_KEY required')
 assert(W3UP_PROOF, 'W3UP_PROOF required')
 
+const maxMeasurements = Number(MAX_MEASUREMENTS_PER_ROUND)
 const client = new pg.Pool({ connectionString: DATABASE_URL })
 
 async function parseProof (data) {
@@ -64,7 +65,7 @@ try {
     ieContract,
     recordTelemetry: recordPublishTelemetry,
     stuckTransactionsCanceller,
-    maxMeasurements: MAX_MEASUREMENTS_PER_ROUND
+    maxMeasurements
   })
 } finally {
   // Ensure telemetry has been submitted before exiting

--- a/publish/bin/spark-publish.js
+++ b/publish/bin/spark-publish.js
@@ -1,7 +1,7 @@
 import '../lib/instrument.js'
 import * as Sentry from '@sentry/node'
 import assert from 'node:assert'
-import { newDelegatedEthAddress } from '@glif/filecoin-address'
+import { newDelegatedEthAddress, CoinType } from '@glif/filecoin-address'
 import timers from 'node:timers/promises'
 import { ethers } from 'ethers'
 import { spawn } from 'node:child_process'
@@ -39,8 +39,7 @@ const stuckTransactionsCanceller = createStuckTransactionsCanceller({ pgClient: 
 console.log(
   'Wallet address:',
   signer.address,
-  // @ts-ignore `signer.address` is declared as `string` but it's actually an `ethers.EthAddress`
-  newDelegatedEthAddress(signer.address, 'f').toString()
+  newDelegatedEthAddress(/** @type {import('@glif/filecoin-address').EthAddress} */ (signer.address), CoinType.MAIN).toString()
 )
 
 await Promise.all([

--- a/publish/bin/spark-publish.js
+++ b/publish/bin/spark-publish.js
@@ -46,7 +46,7 @@ console.log(
 await Promise.all([
   (async () => {
     while (true) {
-      const lastStart = Date.now()
+      const lastStart = new Date()
       const ps = spawn(
         'node',
         [
@@ -71,7 +71,7 @@ await Promise.all([
         console.error(`Bad exit code: ${code}`)
         Sentry.captureMessage(`Bad exit code: ${code}`)
       }
-      const dt = Date.now() - lastStart
+      const dt = new Date().getTime() - lastStart.getTime()
       console.log(`Done. This iteration took ${dt}ms.`)
       if (dt < minRoundLength) await timers.setTimeout(minRoundLength - dt)
     }

--- a/publish/bin/spark-publish.js
+++ b/publish/bin/spark-publish.js
@@ -39,13 +39,14 @@ const stuckTransactionsCanceller = createStuckTransactionsCanceller({ pgClient: 
 console.log(
   'Wallet address:',
   signer.address,
+  // @ts-ignore ethers return address as `string` type, but in fact it's an `0x{string}` type
   newDelegatedEthAddress(signer.address, 'f').toString()
 )
 
 await Promise.all([
   (async () => {
     while (true) {
-      const lastStart = new Date()
+      const lastStart = Date.now()
       const ps = spawn(
         'node',
         [
@@ -55,11 +56,11 @@ await Promise.all([
         {
           env: {
             ...process.env,
-            MIN_ROUND_LENGTH_SECONDS,
-            MAX_MEASUREMENTS_PER_ROUND,
             WALLET_SEED,
             W3UP_PRIVATE_KEY,
-            W3UP_PROOF
+            W3UP_PROOF,
+            MIN_ROUND_LENGTH_SECONDS: MIN_ROUND_LENGTH_SECONDS.toString(),
+            MAX_MEASUREMENTS_PER_ROUND: MAX_MEASUREMENTS_PER_ROUND.toString()
           }
         }
       )
@@ -70,7 +71,7 @@ await Promise.all([
         console.error(`Bad exit code: ${code}`)
         Sentry.captureMessage(`Bad exit code: ${code}`)
       }
-      const dt = new Date() - lastStart
+      const dt = Date.now() - lastStart
       console.log(`Done. This iteration took ${dt}ms.`)
       if (dt < minRoundLength) await timers.setTimeout(minRoundLength - dt)
     }

--- a/publish/bin/spark-publish.js
+++ b/publish/bin/spark-publish.js
@@ -39,7 +39,7 @@ const stuckTransactionsCanceller = createStuckTransactionsCanceller({ pgClient: 
 console.log(
   'Wallet address:',
   signer.address,
-  // @ts-ignore ethers return address as `string` type, but in fact it's an `0x{string}` type
+  // @ts-ignore `signer.address` is declared as `string` but it's actually an `ethers.EthAddress`
   newDelegatedEthAddress(signer.address, 'f').toString()
 )
 

--- a/publish/bin/spark-publish.js
+++ b/publish/bin/spark-publish.js
@@ -1,3 +1,4 @@
+/** @import { EthAddress } from '@glif/filecoin-address' */
 import '../lib/instrument.js'
 import * as Sentry from '@sentry/node'
 import assert from 'node:assert'
@@ -39,7 +40,7 @@ const stuckTransactionsCanceller = createStuckTransactionsCanceller({ pgClient: 
 console.log(
   'Wallet address:',
   signer.address,
-  newDelegatedEthAddress(/** @type {import('@glif/filecoin-address').EthAddress} */ (signer.address), CoinType.MAIN).toString()
+  newDelegatedEthAddress(/** @type {EthAddress} */ (signer.address), CoinType.MAIN).toString()
 )
 
 await Promise.all([

--- a/publish/index.js
+++ b/publish/index.js
@@ -54,14 +54,14 @@ export const publish = async ({
   logger.log(`Publishing ${measurements.length} measurements. Total unpublished: ${totalCount}. Batch size: ${maxMeasurements}.`)
 
   // Share measurements
-  const start = Date.now()
+  const start = new Date()
   const file = new File(
     [measurements.map(m => JSON.stringify(m)).join('\n')],
     'measurements.ndjson',
     { type: 'application/json' }
   )
   const cid = await web3Storage.uploadFile(file)
-  const uploadMeasurementsDuration = Date.now() - start
+  const uploadMeasurementsDuration = new Date().getTime() - start.getTime()
   logger.log(`Measurements packaged in ${cid}`)
 
   // Call contract with CID
@@ -140,7 +140,7 @@ export const publish = async ({
 
 const commitMeasurements = async ({ cid, ieContract, logger, stuckTransactionsCanceller }) => {
   logger.log('Invoking ie.addMeasurements()...')
-  const start = Date.now()
+  const start = new Date()
   const tx = await ieContract.addMeasurements(cid.toString())
   await stuckTransactionsCanceller.addPending(tx)
   logger.log('Waiting for the transaction receipt:', tx.hash)
@@ -151,7 +151,7 @@ const commitMeasurements = async ({ cid, ieContract, logger, stuckTransactionsCa
   }
   const log = ieContract.interface.parseLog(receipt.logs[0])
   const roundIndex = log.args[1]
-  const ieAddMeasurementsDuration = Date.now() - start
+  const ieAddMeasurementsDuration = new Date().getTime() - start.getTime()
   logger.log('Measurements added to round %s in %sms', roundIndex.toString(), ieAddMeasurementsDuration)
 
   return { roundIndex, ieAddMeasurementsDuration }

--- a/publish/index.js
+++ b/publish/index.js
@@ -3,14 +3,6 @@
 import pRetry from 'p-retry'
 import * as SparkImpactEvaluator from '@filecoin-station/spark-impact-evaluator'
 
-class TransactionReceiptError extends Error {
-  constructor (message, tx, receipt) {
-    super(message)
-    this.tx = tx
-    this.receipt = receipt
-  }
-}
-
 export const publish = async ({
   client: pgPool,
   web3Storage,
@@ -155,7 +147,7 @@ const commitMeasurements = async ({ cid, ieContract, logger, stuckTransactionsCa
   const receipt = await tx.wait()
   stuckTransactionsCanceller.removeConfirmed(tx)
   if (receipt.logs.length === 0) {
-    throw new TransactionReceiptError('No logs found in the receipt', tx, receipt)
+    throw Object.assign(new Error('No logs found in the receipt'), { tx, receipt })
   }
   const log = ieContract.interface.parseLog(receipt.logs[0])
   const roundIndex = log.args[1]

--- a/test-helpers/platform-test-helpers.js
+++ b/test-helpers/platform-test-helpers.js
@@ -31,3 +31,11 @@ export const createTelemetryRecorderStub = () => {
 
   return { recordTelemetry, telemetry }
 }
+
+/**
+ * @param {Point} point
+ */
+export const getPointName = (point) => {
+  // Point.name is marked as a private property at the TypeScript level
+  return /** @type {any} */(point).name
+}

--- a/test-helpers/platform-test-helpers.js
+++ b/test-helpers/platform-test-helpers.js
@@ -6,6 +6,7 @@ import { Point } from '@influxdata/influxdb-client'
 export const { DATABASE_URL } = process.env
 
 export const logger = {
+  ...console,
   log () {},
   error (...args) {
     console.error(...args)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "skipLibCheck": true,
+    "lib": ["es2022"],
+    "target": "es2022",
+    "module": "Node16",
+    "moduleResolution": "node16",
+
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+
+    // TODO
+    // "strict": true,
+    "forceConsistentCasingInFileNames": true,
+
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
+    "declarationMap": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "api",
+    "common",
+    "publish",
+    "spark-db"
+  ],
+  "exclude": [
+    "dist/**/*"
+  ]
+}


### PR DESCRIPTION
### Description

Adds typescript support and type checking. Fixes incorrect types and changes block number types to use `BigInt` instead of `number`.

### Change-log

- Add `typescript` package and type packages for `mocha`, `node` and `pg`
- Add typescript type checking as part of `test` command
- Fix incorrect types 
- Convert all block number types to `BigInt` from `number`

Related to https://github.com/CheckerNetwork/roadmap/issues/80