### PR TITLE
feat: require Spark Checker version >=1.17.0

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -59,7 +59,7 @@ const createMeasurement = async (req, res, client) => {
   validate(measurement, 'sparkVersion', { type: 'string', required: false })
   validate(measurement, 'zinniaVersion', { type: 'string', required: false })
   assert(
-    typeof measurement.sparkVersion === 'string' && satisfies(measurement.sparkVersion, '>=1.13.0'),
+    typeof measurement.sparkVersion === 'string' && satisfies(measurement.sparkVersion, '>=1.17.0'),
     410, 'OUTDATED CLIENT'
   )
 

--- a/api/test/test.js
+++ b/api/test/test.js
@@ -14,7 +14,7 @@ import { createTelemetryRecorderStub } from '../../test-helpers/platform-test-he
 
 const { DATABASE_URL } = process.env
 const participantAddress = '0x000000000000000000000000000000000000dEaD'
-const sparkVersion = '1.13.0' // This must be in sync with the minimum supported client version
+const sparkVersion = '1.17.0' // This must be in sync with the minimum supported client version
 const currentSparkRoundNumber = 42n
 
 const VALID_DEAL_INGESTION_TOKEN = 'authorized-token'


### PR DESCRIPTION
We have recently introduced a new requirement - when an HTTP retrieval succeeded, the checker is required to test HEAD retrieval request too.  The preprocessing step in spark-evaluate discards measurements missing `head_status_code`.

Because a large part of the network is running an older version of Spark Checker, measurements from these nodes are rejected as invalid.  See https://github.com/CheckerNetwork/spark-evaluate/pull/498.

This patch is moving the validation step earlier to the pipeline by changing the minimum required Spark Checker version to 1.17.0.

Checker nodes running an older version will start receiving a helpful "OUTDATED CLIENT" error response.

A screenshot from the Spark Internal Dashboard showing the correlation between outdated checker client and rejected measurements:

<img width="921" alt="Screenshot 2025-03-11 at 13 03 13" src="https://github.com/user-attachments/assets/d12d963e-2c8b-4b17-9ceb-9ccbb71e3695" />
