### PR TITLE
chore: Remove domain redirect

### DIFF
--- a/api/bin/spark.js
+++ b/api/bin/spark.js
@@ -12,7 +12,6 @@ import { recordNetworkInfoTelemetry } from '../../common/telemetry.js'
 const {
   PORT = 8080,
   HOST = '127.0.0.1',
-  DOMAIN = 'localhost',
   DATABASE_URL,
   DEAL_INGESTER_TOKEN,
   REQUEST_LOGGING = 'true'
@@ -76,8 +75,7 @@ const logger = {
 const handler = await createHandler({
   client,
   logger,
-  dealIngestionAccessToken: DEAL_INGESTER_TOKEN,
-  domain: DOMAIN
+  dealIngestionAccessToken: DEAL_INGESTER_TOKEN
 })
 
 const port = Number(PORT)

--- a/api/index.js
+++ b/api/index.js
@@ -16,13 +16,9 @@ import { ethAddressFromDelegated } from '@glif/filecoin-address'
  * @param {IncomingMessage} req
  * @param {ServerResponse} res
  * @param {pg.Client} client
- * @param {string} domain
  * @param {string} dealIngestionAccessToken
  */
-const handler = async (req, res, client, domain, dealIngestionAccessToken) => {
-  if (req.headers.host.split(':')[0] !== domain) {
-    return redirect(req, res, `https://${domain}${req.url}`, 301)
-  }
+const handler = async (req, res, client, dealIngestionAccessToken) => {
   const segs = req.url.split('/').filter(Boolean)
   if (segs[0] === 'retrievals' && req.method === 'POST') {
     assert.fail(410, 'OUTDATED CLIENT')
@@ -460,13 +456,12 @@ export const ingestEligibleDeals = async (req, res, client, dealIngestionAccessT
 export const createHandler = async ({
   client,
   logger,
-  dealIngestionAccessToken,
-  domain
+  dealIngestionAccessToken
 }) => {
   return (req, res) => {
     const start = new Date()
     logger.request(`${req.method} ${req.url} ...`)
-    handler(req, res, client, domain, dealIngestionAccessToken)
+    handler(req, res, client, dealIngestionAccessToken)
       .catch(err => errorHandler(res, err, logger))
       .then(() => {
         logger.request(`${req.method} ${req.url} ${res.statusCode} (${new Date().getTime() - start.getTime()}ms)`)

--- a/api/test/test.js
+++ b/api/test/test.js
@@ -69,12 +69,11 @@ describe('Routes', () => {
     const handler = await createHandler({
       client,
       logger: {
-        info () {},
+        info () { },
         error: console.error,
-        request () {}
+        request () { }
       },
-      dealIngestionAccessToken: VALID_DEAL_INGESTION_TOKEN,
-      domain: '127.0.0.1'
+      dealIngestionAccessToken: VALID_DEAL_INGESTION_TOKEN
     })
     server = http.createServer(handler)
     server.listen()
@@ -646,38 +645,6 @@ describe('Routes', () => {
       const body = await res.json()
 
       assert.deepStrictEqual(body, { id: String(2 ** 31) })
-    })
-  })
-
-  describe('Redirect', () => {
-    it('redirects to the right domain', async () => {
-      let server
-      try {
-        const handler = await createHandler({
-          client,
-          logger: {
-            info () {},
-            error: console.error,
-            request () {}
-          },
-          dealIngestionAccessToken: VALID_DEAL_INGESTION_TOKEN,
-          domain: 'foobar'
-        })
-        server = http.createServer(handler)
-        server.listen()
-        await once(server, 'listening')
-        const { port } = /** @type {import('node:net').AddressInfo} */ (server.address())
-        const spark = `http://127.0.0.1:${port}`
-        const res = await fetch(
-          `${spark}/rounds/${currentSparkRoundNumber}`,
-          { redirect: 'manual' }
-        )
-        await assertResponseStatus(res, 301)
-        assert.strictEqual(res.headers.get('location'), `https://foobar/rounds/${currentSparkRoundNumber}`)
-      } finally {
-        server.closeAllConnections()
-        server.close()
-      }
     })
   })
 


### PR DESCRIPTION
This PR removes domain redirects. This is a prerequesite to enabling spark api as an internal service.


Blocking https://github.com/CheckerNetwork/spark-0k-checker/pull/5