### PR TITLE
Revert "chore: Remove domain redirect"

### DIFF
--- a/api/bin/spark.js
+++ b/api/bin/spark.js
@@ -12,6 +12,7 @@ import { recordNetworkInfoTelemetry } from '../../common/telemetry.js'
 const {
   PORT = 8080,
   HOST = '127.0.0.1',
+  DOMAIN = 'localhost',
   DATABASE_URL,
   DEAL_INGESTER_TOKEN,
   REQUEST_LOGGING = 'true'
@@ -75,7 +76,8 @@ const logger = {
 const handler = await createHandler({
   client,
   logger,
-  dealIngestionAccessToken: DEAL_INGESTER_TOKEN
+  dealIngestionAccessToken: DEAL_INGESTER_TOKEN,
+  domain: DOMAIN
 })
 
 const port = Number(PORT)

--- a/api/index.js
+++ b/api/index.js
@@ -16,9 +16,13 @@ import { ethAddressFromDelegated } from '@glif/filecoin-address'
  * @param {IncomingMessage} req
  * @param {ServerResponse} res
  * @param {pg.Client} client
+ * @param {string} domain
  * @param {string} dealIngestionAccessToken
  */
-const handler = async (req, res, client, dealIngestionAccessToken) => {
+const handler = async (req, res, client, domain, dealIngestionAccessToken) => {
+  if (req.headers.host.split(':')[0] !== domain) {
+    return redirect(req, res, `https://${domain}${req.url}`, 301)
+  }
   const segs = req.url.split('/').filter(Boolean)
   if (segs[0] === 'retrievals' && req.method === 'POST') {
     assert.fail(410, 'OUTDATED CLIENT')
@@ -456,12 +460,13 @@ export const ingestEligibleDeals = async (req, res, client, dealIngestionAccessT
 export const createHandler = async ({
   client,
   logger,
-  dealIngestionAccessToken
+  dealIngestionAccessToken,
+  domain
 }) => {
   return (req, res) => {
     const start = new Date()
     logger.request(`${req.method} ${req.url} ...`)
-    handler(req, res, client, dealIngestionAccessToken)
+    handler(req, res, client, domain, dealIngestionAccessToken)
       .catch(err => errorHandler(res, err, logger))
       .then(() => {
         logger.request(`${req.method} ${req.url} ${res.statusCode} (${new Date().getTime() - start.getTime()}ms)`)


### PR DESCRIPTION
As we have decided on not using private networking to communicate between permissioned `spark-0k` nodes and the `spark-api` domain redirect should not pose an issue anymore. 

Reverts CheckerNetwork/spark-api#647

Related to #652 